### PR TITLE
chore: Only run "Verify Pull Request" workflow on pull requests

### DIFF
--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -1,10 +1,6 @@
 name: Verify Pull Request
 
 on:
-  push:
-    branches:
-      - develop
-      - release
   pull_request:
     branches:
       - release


### PR DESCRIPTION
No longer runs the "Verify Pull Request" workflow on push to develop or release branches