### PR TITLE
ci: cache npm packages on workflows

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -19,9 +19,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Build
         run: |
           yarn install --frozen-lockfile

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build

--- a/.github/workflows/verify-code.yml
+++ b/.github/workflows/verify-code.yml
@@ -15,11 +15,12 @@ jobs:
         node-version: [12.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: npm install, build, and test
         run: |
           yarn install --frozen-lockfile

--- a/.github/workflows/verify-commits.yml
+++ b/.github/workflows/verify-commits.yml
@@ -13,9 +13,9 @@ jobs:
     name: Verify commit style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/verify-commits.yml
+++ b/.github/workflows/verify-commits.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Install
         run: yarn install --frozen-lock
       - name: Run commitlint on commits

--- a/.github/workflows/verify-pr-title.yml
+++ b/.github/workflows/verify-pr-title.yml
@@ -15,11 +15,12 @@ jobs:
     name: Verify Title
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Install
         run: yarn install --frozen-lock
       - name: Run commitlint against PR title


### PR DESCRIPTION
- Updates all github workflows to use actions/checkout@v2 and actions/setup-node@v2
- Updates all github (excluding non release) workflows to cache yarn dependencies