### PR TITLE
docs: remove HOCs and components support from tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React with RxJS
 
-A set of hooks, HOCs, and components for creating and consuming RxJS observables.
+A set of hooks for creating and consuming RxJS observables.
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 home: true
 heroText: React with RxJS
-tagline: A set of hooks, HOCs, and components for creating and consuming RxJS observables.
+tagline: A set of hooks for creating and consuming RxJS observables.
 actionText: Get Started →
 actionLink: /guide/installation
 footer: MIT License | Copyright (c) 2021 Samuel Carnell


### PR DESCRIPTION
- Removes mention of support for HOCs and component as this has been postponed for future releases