### PR TITLE
ci(publish-release): run yarn build before publishing a new release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env
+      - name: yarn build
+        run: yarn build
       - name: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
     "@semantic-release/changelog": "^6.0.0",
-    "@semantic-release/exec": "^6.0.1",
     "@semantic-release/git": "^10.0.0",
     "@size-limit/preset-small-lib": "^5.0.1",
     "@testing-library/jest-dom": "^5.14.1",

--- a/release.config.js
+++ b/release.config.js
@@ -41,12 +41,6 @@ module.exports = {
 			},
 		],
 		[
-			'@semantic-release/exec',
-			{
-				prepareCmd: 'yarn build',
-			},
-		],
-		[
 			'@semantic-release/npm',
 			{
 				pkgRoot: 'dist',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,18 +1979,6 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
 
-"@semantic-release/exec@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-6.0.1.tgz#6316f52ad786c7fafff5e1cbcfeeb7608501db78"
-  integrity sha512-RlMoxuhQ7QujrykIG5uw0NU6x82BR4E7ssKsl+ISCFhFHnvxxH+w4h4klWOs/cT/XEPJdoPFbBOVoruKtAwfDg==
-  dependencies:
-    "@semantic-release/error" "^2.1.0"
-    aggregate-error "^3.0.0"
-    debug "^4.0.0"
-    execa "^5.0.0"
-    lodash "^4.17.4"
-    parse-json "^5.0.0"
-
 "@semantic-release/git@^10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-10.0.0.tgz#41dda434e9c2fe222d030f12060e6f5a8696e7ba"


### PR DESCRIPTION
Runs the `yarn build` command before running `yarn release`. Subsequently the `@semantic-release/exec` plugin is no longer required.

Previously the `yarn build` would run as a part of prepare step of semantic release using the `@semantic-release/exec` plugin. The issue with this is that the `@semantic-release/npm` plugin checks that the `dist/package.json` file exists before the command has run, causing semantic release to error out. By running the command before semantic release runs, the `dist/package.json` is guaranteed to exist.

The drawback to this is that the `yarn build` command will always run even if a new release isn't required.